### PR TITLE
Add compatibility with reverse proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,23 @@ Retro font plugin for Noobish's [FM-DX Webserver](https://github.com/NoobishSVK/
 
 ## Installation
 
-Copy retro-font.js and retro-font folder to the plugins directory of your FM-DX-webserver installation, then copy font.ttf to the **web** directory of your webserver, not the plugins directory.
+ - Copy all the contents of the plugins folder to the plugins directory of your FM-DX-webserver installation.
+ - Copy the retrofont folder and its contents to the web directory of your webserver, not the plugins directory!
 
 Navigate to the plugins menu in the admin panel, and enable the plugin.
 
-You can modify retro-font.js to specify if you only want the font of the frequency to change. This is optional.
+You can modify the font and select if you want the PS text to use the font in the settings menu.
 
 # New fonts
 
-There are now 3 different font options pre-installed:
+There are now 9 different extra font options included:
 
- - font.ttf - The default 7 segment display 
- - font-bkram.ttf - The font used on Bkram's Haaglanden webserver
- - font-minisystem.otf - Font suggested by LaceK_85
+ - Retro - The default 7 segment display
+ - OpenDyslexic
+ - Sony XDR - Font suggested by LaceK_85
+ - VFD
+ - XHDATA
+ - Dots
+ - Pixelyourlife
+ - RumAndBones
+ - NinePin

--- a/plugins/retro-font/retro-font.js
+++ b/plugins/retro-font/retro-font.js
@@ -79,7 +79,7 @@ function loadFont(url) {
         return;
     }
 
-    let fullUrl = window.location.origin + '/' + url;
+    let fullUrl = window.location.origin + window.location.pathname + '/' + url;
     const font = new FontFace("Retro-font", `url(${fullUrl})`);
     font.load().then(function (loadedFont) {
         document.fonts.add(loadedFont);


### PR DESCRIPTION
I added the path to the url of the retrofont directory to make it work with reverse proxies that use a folder like I do with https://ctrl.fm-tuner.nl
Different tuners are accessible on subfolders:
https://ctrl.fm-tuner.nl/almere/
https://ctrl.fm-tuner.nl/utrecht/
https://ctrl.fm-tuner.nl/zierikzee/
etc.
Updated the readme a bit to reflect some of the updates like multiple fonts installation.